### PR TITLE
Better maxslice size to avoid problems on ARM 

### DIFF
--- a/ejcoll.go
+++ b/ejcoll.go
@@ -121,7 +121,7 @@ func (coll *EjColl) Update(query string, queries ...string) (int, *EjdbError) {
 
     orqueries := C.malloc(C.size_t(unsafe.Sizeof(C.bson{})) * C.size_t(len(queries)))
     defer C.free(orqueries)
-    ptr_orqueries := (*[maxslice]C.bson)(orqueries)
+    ptr_orqueries := (*[maxslice / unsafe.Sizeof(C.bson{})]C.bson)(orqueries)
     for i, q := range queries {
         bson := bson_from_json(q)
         (*ptr_orqueries)[i] = *bson

--- a/ejdb.go
+++ b/ejdb.go
@@ -62,7 +62,7 @@ const (
     JBEMAXNUMCOLS = C.JBEMAXNUMCOLS
 )
 
-const maxslice = 1<<31 - 1
+const maxslice = 0x7FFFFFFF
 
 // An EJDB database
 type Ejdb struct {


### PR DESCRIPTION
This pull requests fixes (if I'm not wrong) the issue #3 where compiling goejdb in raspberry pi (and in my case in an scaleway arm server) was giving some problems.

The compile problem was this:

```
goejdb/ejcoll.go:124: type [2147483647]C.struct___0 larger than address space
goejdb/ejcoll.go:124: type [2147483647]C.struct___0 too large
```

It seems that the const `maxslice` was too big. But how much? It seems it's a hot issue as seen here golang/go#13656 So I took the approach to see what other projects where doing, in this case [bolt](https://github.com/boltdb/bolt) and in their `bolt_*` files they use a 2GB address space.

So that's the first change, reduced the address space to 2GB. After that still this needs to be divided by the size of the item in the array or again the compiler will rise the error.

What do you think?
